### PR TITLE
adding two missing proxies

### DIFF
--- a/naoutil/src/main/python/naoutil/naoenv.py
+++ b/naoutil/src/main/python/naoutil/naoenv.py
@@ -179,10 +179,10 @@ class NaoEnvironment(object):
 
     # invoke ALProxy to store the proxy we need
     def add_proxy(self, longName):
-        self.proxies[longName] = self.get_proxy(longName)
+        self.proxies[longName] = self.create_proxy(longName)
 
-    # invoke ALProxy to get the proxy we need
-    def get_proxy(self, longName):
+    # invoke ALProxy to create the proxy we need
+    def create_proxy(self, longName):
         if self.proxyAddr and self.proxyPort:
             self.logger.debug('Creating proxy: {name} at {proxy.proxyAddr}:{proxy.proxyPort}'.format(name=longName, proxy=self))
             return ALProxy(longName, self.proxyAddr, self.proxyPort)


### PR DESCRIPTION
refactored add_proxy
- extract method - to pull the creating of the proxy out into a method called create_proxy
- updated the comment on add_proxy to say it "stores the proxy we need"
- add_proxy now delegates the work of creating the proxy to create_proxy

create_proxy is useful if the proxy is missing from the list and I just want to get it by long name really quickly, finish my work and then go add it to the list later. :)
